### PR TITLE
Create dirs for curl, and don't silence output:

### DIFF
--- a/lib/heaven/provider/bundler_capistrano.rb
+++ b/lib/heaven/provider/bundler_capistrano.rb
@@ -31,7 +31,7 @@ module Heaven
 
         unless File.exist?(archive_path)
           log "Downloading #{archive_link} into #{archive_path}"
-          execute_and_log(["curl", "-sL", archive_link, "-o", archive_path])
+          execute_and_log(["curl", "--create-dirs", "-L", archive_link, "-o", archive_path])
         end
 
         unless Dir.exist?(unpacked_directory)


### PR DESCRIPTION
This is failing for us in mysterious ways, not sure how this works in
other environments:

* curl tries to download the release into a directory that does not
exist
* the log concern tries to log the output into that same dir (which doesn't exist)
* File.open raises an exception