### PR TITLE
Fallback to unknown user for notifier

### DIFF
--- a/lib/heaven/notifier/default.rb
+++ b/lib/heaven/notifier/default.rb
@@ -100,8 +100,8 @@ module Heaven
       end
 
       def chat_user
-        deployment_payload["notify"]["user_name"] ||
-          deployment_payload["notify"]["user"] || "unknown"
+        return "unknown" unless deployment_payload["notify"]
+        deployment_payload["notify"]["user_name"] || deployment_payload["notify"]["user"] || "unknown"
       end
 
       def chat_room

--- a/spec/lib/heaven/notifier/default_spec.rb
+++ b/spec/lib/heaven/notifier/default_spec.rb
@@ -1,6 +1,32 @@
 require "spec_helper"
 
 describe "Heaven::Notifier::Default" do
+  context "chat_user" do
+    it "returns user from notify data from payload" do
+      data = {
+        "deployment" => {
+          "payload" => {
+            "notify" => {
+              "user_name" => "sarahconnor"
+            }
+          }
+        }
+      }
+      notifier = Heaven::Notifier::Default.new(data)
+      expect(notifier.chat_user).to eq("sarahconnor")
+    end
+
+    it "returns unknown chat user if payload is empty" do
+      data = { "deployment" => {
+        "payload" => {}
+        }
+      }
+      notifier = Heaven::Notifier::Default.new(data)
+      expect(notifier.chat_user).to eq("unknown")
+    end
+
+  end
+
   it "does not deliver changes unless an environment opt-in is present" do
     notifier = Heaven::Notifier::Default.new("{}")
 


### PR DESCRIPTION
We shouldn't require a `user_name` or `user` from a `notify` hash in the `payload`.

Holy hell that is a lot of nested hashes.

Anyways, we should be able to just use the name of `unknown` if the client hasn't configured any of this when creating their deployment.

The whole notification piece could really use much better docs.  See also the `chat_room` piece, which isn't actually require by Slack but is required in the default provider.