### PR TITLE
Dont set slack channel if not provided in Deployment

### DIFF
--- a/lib/heaven/notifier/slack.rb
+++ b/lib/heaven/notifier/slack.rb
@@ -22,7 +22,7 @@ module Heaven
             :pretext => pending? ? output_message : " "
           }]
         }
-        options.merge!(channel: "#{chat_room}") # if chat_room
+        options.merge!(channel: "#{chat_room}") if chat_room
         slack_account.ping "", options
       end
 

--- a/lib/heaven/notifier/slack.rb
+++ b/lib/heaven/notifier/slack.rb
@@ -12,8 +12,8 @@ module Heaven
         Rails.logger.info "message: #{message}"
 
         output_message << "##{deployment_number} - #{repo_name} / #{ref} / #{environment}"
-        slack_account.ping "",
-          :channel     => "##{chat_room}",
+
+        options = {
           :username    => slack_bot_name,
           :icon_url    => slack_bot_icon,
           :attachments => [{
@@ -21,6 +21,9 @@ module Heaven
             :color   => green? ? "good" : "danger",
             :pretext => pending? ? output_message : " "
           }]
+        }
+        options.merge!(channel: "#{chat_room}") # if chat_room
+        slack_account.ping "", options
       end
 
       def default_message

--- a/spec/lib/heaven/notifier/slack_spec.rb
+++ b/spec/lib/heaven/notifier/slack_spec.rb
@@ -3,6 +3,15 @@ require "spec_helper"
 describe "Heaven::Notifier::Slack" do
   include FixtureHelper
 
+  it "does not require a chat room" do
+    Heaven.redis.set("atmos/my-robot-production-revision", "sha")
+
+    data = decoded_fixture_data("deployment-success")
+    data["deployment"]["payload"]["notify"].delete("room")
+
+    notifier = Heaven::Notifier::Slack.new(data)
+  end
+
   it "handles pending notifications" do
     Heaven.redis.set("atmos/my-robot-production-revision", "sha")
 


### PR DESCRIPTION
The Slack webhook configures a default channel, so there is no reason to
always send along a chat room ....its entirely possible to just provide
the SLACK_WEBHOOK_URL and get up and running w/ notifications.